### PR TITLE
Fix send to specific/all users

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -83,7 +83,11 @@
         var obj = {};
         $('.value').each(function () {
             var $this = $(this);
-            obj[$this.attr('id')] = $this.val();
+            if ($this.attr('type') == 'checkbox') {
+                obj[$this.attr('id')] = $this.prop('checked');
+            } else {
+                obj[$this.attr('id')] = $this.val();
+            }
         });
 
         if ($('#passwordRepeat').val() !== obj.password) {

--- a/main.js
+++ b/main.js
@@ -74,7 +74,7 @@ function sendMessage(text, user) {
         return count;
     }
 
-    var m = text.match(/\b@(.+)\b/);
+    var m = text.match(/^@(.+?)\b/);
     if (m) {
         text = text.replace('@' + m[1], '').trim().replace(/\s\s/g, ' ');
         for (u in users) {

--- a/main.js
+++ b/main.js
@@ -78,7 +78,8 @@ function sendMessage(text, user) {
     if (m) {
         text = text.replace('@' + m[1], '').trim().replace(/\s\s/g, ' ');
         for (u in users) {
-            if (users[u] == m[1]) {
+            var re = new RegExp(m[1],'i');
+            if (users[u].match(re)) {
                 count++;
                 if (text.match(/\.(jpg|png|jpeg|bmp)$/i) && fs.existsSync(text)) {
                     adapter.log.debug('Send photo to "' + m[1] + '": ' + text);

--- a/main.js
+++ b/main.js
@@ -101,7 +101,7 @@ function sendMessage(text, user) {
                 adapter.log.debug('Send message to "' + users[u] + '": ' + text);
                 bot.sendMessage(u, text);
             }
-            break;
+            //break;
         }
     }
     return count;


### PR DESCRIPTION
**fix send to specific User with "@user message":**
regexp `\b` matches only between words.
-> Fixed to match at start of message and **only** the one word behind @ (non greedy). 

**fix send to all users #1 :**
commented the `break;` in the for-loop. I don't see why it should break there.

**fix rememberUsers #2 :**
see [comment below](https://github.com/ioBroker/ioBroker.telegram/pull/3#issuecomment-209498862)