### PR TITLE
Change the recipient parameter to "chatId" to also support group chats

### DIFF
--- a/admin/blockly.js
+++ b/admin/blockly.js
@@ -97,6 +97,6 @@ Blockly.JavaScript['telegram'] = function(block) {
     }
 
     return 'sendTo("telegram' + dropdown_instance + '", "send", {\n    text: ' +
-        value_message + (value_username ? ', \n    user: ' + value_username : '') + '\n});\n' +
+        value_message + (value_username ? ', \n    chatId: ' + value_username : '') + '\n});\n' +
         logText;
 };

--- a/admin/blockly.js
+++ b/admin/blockly.js
@@ -97,6 +97,6 @@ Blockly.JavaScript['telegram'] = function(block) {
     }
 
     return 'sendTo("telegram' + dropdown_instance + '", "send", {\n    text: ' +
-        value_message + (value_username ? ', \n    chatId: ' + value_username : '') + '\n});\n' +
+        value_message + (value_username ? ', \n    ' + (value_username.startsWith('-',1) ? 'chatId: ' : 'user: ') + value_username : '') + '\n});\n' +
         logText;
 };


### PR DESCRIPTION
solves issue #65 
In the Blockly element, change the recipient parameter  in the Javascript from "user" to "chatId" in order to also support group chats.
This will NOT break and NOT change  the current behavior, but will add an extra feature.
No additional documentation needed.