### PR TITLE
Added Telegram Bot API URL as configurable parameter

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -207,10 +207,10 @@
                     <td><input id="token" class="value inputStyle" /></td>
                     <td><a href="https://github.com/ioBroker/ioBroker.telegram#iobroker-telegram-adapter" target="_blank" class="translate help">Read README.md how to get token</a></td>
                 </tr>
-		<tr>
-		    <td class="translate">API URL</td>
-		    <td><input id="baseapiurl" class="value inputStyle" /></td>
-		</tr>
+				<tr>
+		    		<td class="translate">API URL</td>
+					<td><input id="baseApiUrl" class="value inputStyle" /></td>
+				</tr>
                 <tr>
                     <td class="translate">Password</td>
                     <td><input id="password" class="value inputStyle" type="password"/></td>

--- a/admin/index.html
+++ b/admin/index.html
@@ -207,6 +207,10 @@
                     <td><input id="token" class="value inputStyle" /></td>
                     <td><a href="https://github.com/ioBroker/ioBroker.telegram#iobroker-telegram-adapter" target="_blank" class="translate help">Read README.md how to get token</a></td>
                 </tr>
+		<tr>
+		    <td class="translate">API URL</td>
+		    <td><input id="baseapiurl" class="value inputStyle" /></td>
+		</tr>
                 <tr>
                     <td class="translate">Password</td>
                     <td><input id="password" class="value inputStyle" type="password"/></td>

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -263,8 +263,8 @@
                 </div>
                 <div class="row">
                     <div class="input-field col s12 m8 l8">
-                        <input id="baseapiurl" type="text" class="value" />
-                        <label class="translate" for="baseapiurl">API URL</label>
+                        <input id="baseApiUrl" type="text" class="value" />
+                        <label class="translate" for="baseApiUrl">API URL</label>
                     </div>
                 </div>
                 <div class="row">

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -262,6 +262,12 @@
                     </div>
                 </div>
                 <div class="row">
+                    <div class="input-field col s12 m8 l8">
+                        <input id="baseapiurl" type="text" class="value" />
+                        <label class="translate" for="baseapiurl">API URL</label>
+                    </div>
+                </div>
+                <div class="row">
                     <div class="input-field col s12 m6 l5">
                         <input id="password" class="value" type="password" />
                         <label class="translate" for="password">password</label>

--- a/io-package.json
+++ b/io-package.json
@@ -275,7 +275,7 @@
         "port": 8443,
         "bind": "0.0.0.0",
         "token": "",
-	"baseapiurl": "https://api.telegram.org",
+	"baseApiUrl": "https://api.telegram.org",
         "password": "",
         "text2command": "",
         "rememberUsers": true,

--- a/io-package.json
+++ b/io-package.json
@@ -275,6 +275,7 @@
         "port": 8443,
         "bind": "0.0.0.0",
         "token": "",
+	"baseapiurl": "https://api.telegram.org",
         "password": "",
         "text2command": "",
         "rememberUsers": true,

--- a/main.js
+++ b/main.js
@@ -1202,7 +1202,8 @@ function connect() {
             // Setup server way
             const serverOptions = {
                 polling: false,
-                filepath: true
+                filepath: true,
+		baseApiUrl: adapter.config.baseapiurl
             };
             if (agent) {
                 serverOptions.request = { agent: agent };
@@ -1218,7 +1219,8 @@ function connect() {
                 polling: {
                     interval: parseInt(adapter.config.pollingInterval, 10) || 300
                 },
-                filepath: true
+                filepath: true,
+		baseApiUrl: adapter.config.baseapiurl
             };
             if (agent) {
                 pollingOptions.request = { agent: agent };

--- a/main.js
+++ b/main.js
@@ -1203,7 +1203,7 @@ function connect() {
             const serverOptions = {
                 polling: false,
                 filepath: true,
-		baseApiUrl: adapter.config.baseapiurl
+		baseApiUrl: adapter.config.baseApiUrl
             };
             if (agent) {
                 serverOptions.request = { agent: agent };
@@ -1220,7 +1220,7 @@ function connect() {
                     interval: parseInt(adapter.config.pollingInterval, 10) || 300
                 },
                 filepath: true,
-		baseApiUrl: adapter.config.baseapiurl
+		baseApiUrl: adapter.config.baseApiUrl
             };
             if (agent) {
                 pollingOptions.request = { agent: agent };


### PR DESCRIPTION
Different countries have government-issued internet regulations and/or laws that prevent this adapter to use official Bot API URL (https://api.telegram.org), so many people need to proxy bot API requests.
This change gives an opportunity to enter own proxy URL. 